### PR TITLE
performance optimization: don't replace characters unless we have to

### DIFF
--- a/src/main/java/org/sotnya/lemmatizer/uk/engine/UkrainianLemmatizer.java
+++ b/src/main/java/org/sotnya/lemmatizer/uk/engine/UkrainianLemmatizer.java
@@ -22,13 +22,16 @@ public class UkrainianLemmatizer {
      * Right now there is the single substitution case: ukrainian apostrophes with to english single quote.
      */
     private static final Map<Character, Character> replaceItems = new HashMap<Character, Character>(2) {{
-        put('’', '\'');
-        put('ʼ', '\'');
+        put('\u2019', '\'');
+        put('\u02BC', '\'');
     }};
+
     /**
      * Ignore stress symbol
      */
-    private static final String[] IGNORE_CHARS = new String[] { "\u0301" };
+    private static final String[] IGNORE_CHARS = new String[] {
+        "\u0301"
+    };
 
 
     static {
@@ -62,9 +65,7 @@ public class UkrainianLemmatizer {
         String term = termAtt.toString();
 
         for (Map.Entry<Character, Character> e : replaceItems.entrySet()) {
-            if( term.indexOf(e.getKey()) != -1 ) {
-                term = term.replace(e.getKey(), e.getValue());
-            }
+            term = term.replace(e.getKey(), e.getValue());
         }
 
         for (String ignoreChar: IGNORE_CHARS) {

--- a/src/main/java/org/sotnya/lemmatizer/uk/engine/UkrainianLemmatizer.java
+++ b/src/main/java/org/sotnya/lemmatizer/uk/engine/UkrainianLemmatizer.java
@@ -62,11 +62,15 @@ public class UkrainianLemmatizer {
         String term = termAtt.toString();
 
         for (Map.Entry<Character, Character> e : replaceItems.entrySet()) {
-            term = term.replace(e.getKey(), e.getValue());
+            if( term.indexOf(e.getKey()) != -1 ) {
+                term = term.replace(e.getKey(), e.getValue());
+            }
         }
 
         for (String ignoreChar: IGNORE_CHARS) {
-            term = term.replace(ignoreChar, "");
+            if( term.contains(ignoreChar) ) {
+                term = term.replace(ignoreChar, "");
+            }
         }
 
         return dictionary.containsKey(term) ? Optional.of(dictionary.get(term)) : Optional.empty();


### PR DESCRIPTION
This may seem minor but on my i7 for 10 000 000 invocations for words that mostly don't include replacable characters (which matches most words in Ukrainian texts) the time for lemmatize() goes from 1700 ms to 300 ms. So for lemmatizing big amount of text this will provide significant performance improvement.
